### PR TITLE
The HOSTS var is controlled in the Github Settings -> Secrets and

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Node.js CI
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   cache-modules:

--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ This is the structure of a Quasar project with all modes installed.
 └── README.md                # readme for your website/App
 ```
 
+## Auto Deploy
+
+The Github action `ci.yml` deploys the app on merges. It requires there to be the appropriate target IP addresses in the Settings -> Secrets and Variables -> Actions -> HOSTS as a space separated list.
+
 ## License
 
  [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)

--- a/config/make_hosts.py
+++ b/config/make_hosts.py
@@ -1,9 +1,11 @@
 import os
 
 HOSTS = os.getenv('HOSTS')
+if not (HOSTS and HOSTS.strip()):
+	raise SystemExit("HOSTS var empty")
 ips = HOSTS.split(" ")
-file = open("hosts", "w") 
+file = open("hosts", "w")
 file.write("[badiCalBadiEventsApp]\n")
 for index, ip in enumerate(ips):
-	file.write('inv%s ansible_ssh_host=%s\n'%(index, ip)) 
+	file.write('inv%s ansible_ssh_host=%s\n'%(index, ip))
 file.close()


### PR DESCRIPTION
The HOSTS var is controlled in the Github Settings -> Secrets and Variables.

That was edited to be blank so the deploys stop.

Screenshot 1
![Screenshot 2024-01-16 at 21-00-46 Build software better together](https://github.com/Badi-Cal/badi-events-app/assets/5190228/0ddb3ee4-cf34-4c07-b546-7aea29dd5ced)

Screenshot 2
![Screenshot 2024-01-16 at 21-01-08 Build software better together](https://github.com/Badi-Cal/badi-events-app/assets/5190228/639421c8-9b10-4875-aab9-2986b61c2634)

I updated this value to work. I'm not sure why it was deleted.


I added a var to (hopefully) allow us to run the deploy from the GH UI.

I also added a raise in the host code.